### PR TITLE
fix: 修正 SEO 可被搜尋問題

### DIFF
--- a/composables/useSEOMeta.ts
+++ b/composables/useSEOMeta.ts
@@ -47,8 +47,6 @@ export const useSEOMeta = (data: SEOData) => {
     twitterTitle: seoTitle.value,
     twitterDescription: seoDescription.value,
     twitterImage: seoImage.value,
-    twitterSite: "@your_twitter",
-    twitterCreator: "@your_twitter",
   });
 
   // 文章特定的 meta tags

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -93,8 +93,6 @@ export default defineNuxtConfig({
         },
         // Twitter Cards
         { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:site", content: "@your_twitter" },
-        { name: "twitter:creator", content: "@your_twitter" },
         { name: "twitter:title", content: "Mike 的部落格網站" },
         {
           name: "twitter:description",
@@ -114,7 +112,7 @@ export default defineNuxtConfig({
     baseURL: process.env.NODE_ENV === "production" ? "/my-blog/" : "/",
   },
   site: {
-    url: "https://my-blog-taupe-one.vercel.app",
+    url: "https://my-blog-taupe-one.vercel.app/my-blog",
     name: "Mike's Blog",
     description:
       "前端開發、Vue、Coding、自學、AI 探索，支援網頁設計與職涯轉職。",
@@ -130,7 +128,6 @@ export default defineNuxtConfig({
     sources: ["/api/_sitemap-urls"],
   },
   robots: {
-    robotsTxt: false,
     sitemap: "https://my-blog-taupe-one.vercel.app/my-blog/sitemap.xml",
   },
 });


### PR DESCRIPTION
## 問題背景

經過診斷，發現博客目前 Google **完全沒有索引任何頁面**（`site:my-blog-taupe-one.vercel.app` 結果為零），原因是以下三個問題同時存在。

## 修正內容

### 1. 移除 `robotsTxt: false`
`@nuxtjs/robots` 模組被設為 `robotsTxt: false`，導致 `/robots.txt` 根本沒有被服務。Googlebot 只認 `https://domain/robots.txt` 這個標準路徑，找不到就無法得知 Sitemap 位置。移除此設定後，模組會自動產生 `/robots.txt` 並合併 `public/_robots.txt` 中的自訂規則。

### 2. 修正 `site.url` 加入 `/my-blog` base path
原本 `site.url` 為 `https://my-blog-taupe-one.vercel.app`，但網站實際部署在 `/my-blog/` 子路徑下。`@nuxtjs/seo` 與 `@nuxtjs/sitemap` 依賴此值產生 canonical URL 及 sitemap 完整路徑，路徑不符會導致 Google 視 canonical 為無效而降低索引優先級。

### 3. 移除 Twitter 占位符
`twitter:site` 與 `twitter:creator` 的值為 `@your_twitter`，無實際 Twitter 帳號，一併移除避免留下無效標籤。

## 影響範圍

- `nuxt.config.ts`
- `composables/useSEOMeta.ts`

## 後續建議

部署後請至 Google Search Console 手動提交 Sitemap：
`https://my-blog-taupe-one.vercel.app/my-blog/sitemap.xml`

https://claude.ai/code/session_01JjHwTuM3YU89AZSPCZc72v

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjHwTuM3YU89AZSPCZc72v)_